### PR TITLE
enable versioned references

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.starter;
 
+import ca.uhn.fhir.context.FhirContext;
 import javax.servlet.ServletException;
 
 public class JpaRestfulServer extends BaseJpaRestfulServer {
@@ -9,6 +10,9 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
   protected void initialize() throws ServletException {
     super.initialize();
     // Add your own customization here
+
+    FhirContext ctx = getFhirContext();
+    ctx.getParserOptions().setStripVersionsFromReferences(false);
 
   }
 }


### PR DESCRIPTION
---
🚀 New Feature
---

### 🚀 Description
This PR enables versioned references in order to not strip resource versions from references between resources

### 🧰 Technical Solution

- [ ] set `setStripVersionsFromReferences` to `false`


