### PR TITLE
Fix server url in hapi properties

### DIFF
--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -11,7 +11,7 @@ fhir_version=R4
 # (the web UI similar to the one at http://hapi.fhir.org) will use to
 # connect internally to the FHIR server, so this also needs to be a name
 # accessible from the server itself.
-server_address=http://localhost:8080/fhir/
+server_address=http://localhost:8080/api/fhir/
 
 enable_index_missing_fields=false
 auto_create_placeholder_reference_targets=false


### PR DESCRIPTION
This PR fixes invalid URLs in pagination pointers.

### 🚒 Technical Solution
[How did you fix this bug?]
- [ ] Adjusted the server url inside the hapi properies