### PR TITLE
enable fhirpath-interceptor

### DIFF
--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -62,7 +62,7 @@ validation.responses.enabled=false
 filter_search.enabled=true
 graphql.enabled=true
 # See FhirPathFilterInterceptor
-fhirpath_interceptor.enabled=false
+fhirpath_interceptor.enabled=true
 
 ###################################################
 # Supported Resources


### PR DESCRIPTION
---
🧯 Bugfix
---

Requests on `api/fhir/resourceType?_fhirPath=xxx` were ignored due to fhir path being disabled as default

### 🚒 Technical Solution
- [x] enabled `fhirpath_interceptor` in hapi.properties