### PR TITLE
audit trail - log username 

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
@@ -32,6 +32,7 @@ public class AuthenticationInterceptor {
     }
     if (theRequestDetails.getHeader("X-Forwarded-User") != null) {
       String username = theRequestDetails.getHeader("X-Forwarded-User");
+      UsernameLogger.logUsername(username, theRequestDetails, restOperationType);
       return;
     }
     throw new AuthenticationException("Authentication failed.");

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
@@ -3,6 +3,7 @@ package ca.uhn.fhir.jpa.starter.dotBase.interceptors;
 import ca.uhn.fhir.interceptor.api.Hook;
 import ca.uhn.fhir.interceptor.api.Pointcut;
 import ca.uhn.fhir.jpa.starter.dotBase.services.Authentication;
+import ca.uhn.fhir.jpa.starter.dotBase.services.UsernameLogger;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
@@ -26,6 +27,7 @@ public class AuthenticationInterceptor {
      */
     if (theRequestDetails.getHeader("Authorization") != null) {
       Claims jwt = Authentication.verifyAndDecodeJWT(theRequestDetails);
+      UsernameLogger.log(jwt, theRequestDetails, restOperationType);
       return;
     }
     if (theRequestDetails.getHeader("X-Forwarded-User") != null) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -13,16 +13,16 @@ import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Meta;
 
 public class UsernameLogger {
-  private static final org.slf4j.Logger OUR_LOG = org.slf4j.LoggerFactory.getLogger(
+  private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(
     UsernameLogger.class
   );
-  private static final Set<RestOperationTypeEnum> RESOURCE_OPERATIONS;
+  private static final Set<RestOperationTypeEnum> RESOURCE_EDITING_OPERATIONS;
 
   static {
-    RESOURCE_OPERATIONS = new HashSet<RestOperationTypeEnum>();
-    RESOURCE_OPERATIONS.add(RestOperationTypeEnum.CREATE);
-    RESOURCE_OPERATIONS.add(RestOperationTypeEnum.UPDATE);
-    RESOURCE_OPERATIONS.add(RestOperationTypeEnum.PATCH);
+    RESOURCE_EDITING_OPERATIONS = new HashSet<RestOperationTypeEnum>();
+    RESOURCE_EDITING_OPERATIONS.add(RestOperationTypeEnum.CREATE);
+    RESOURCE_EDITING_OPERATIONS.add(RestOperationTypeEnum.UPDATE);
+    RESOURCE_EDITING_OPERATIONS.add(RestOperationTypeEnum.PATCH);
   }
 
   public static void log(
@@ -39,14 +39,14 @@ public class UsernameLogger {
     return jwt.get("preferred_username").toString();
   }
 
-  private static void logUsername(
+  public static void logUsername(
     String username,
     RequestDetails theRequestDetails,
     RestOperationTypeEnum restOperationType
   ) {
     setSentryUser(username);
     theRequestDetails.setAttribute("_username", username);
-    if (RESOURCE_OPERATIONS.contains(restOperationType)) setResourceUserExtension(
+    if (RESOURCE_EDITING_OPERATIONS.contains(restOperationType)) setResourceUserExtension(
       username,
       theRequestDetails
     );

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -9,7 +9,6 @@ import java.util.HashSet;
 import java.util.Set;
 import org.hl7.fhir.r4.model.DomainResource;
 import org.hl7.fhir.r4.model.Extension;
-import org.hl7.fhir.r4.model.Meta;
 import org.hl7.fhir.r4.model.StringType;
 
 public class UsernameLogger {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -1,0 +1,74 @@
+package ca.uhn.fhir.jpa.starter.dotBase.services;
+
+import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import io.jsonwebtoken.Claims;
+import io.sentry.Sentry;
+import io.sentry.protocol.User;
+import java.util.HashSet;
+import java.util.Set;
+import org.hl7.fhir.r4.model.DomainResource;
+import org.hl7.fhir.r4.model.Extension;
+import org.hl7.fhir.r4.model.Meta;
+import org.hl7.fhir.r4.model.StringType;
+
+public class UsernameLogger {
+  private static final org.slf4j.Logger OUR_LOG = org.slf4j.LoggerFactory.getLogger(
+    UsernameLogger.class
+  );
+  private static final Set<RestOperationTypeEnum> RESOURCE_OPERATIONS;
+
+  static {
+    RESOURCE_OPERATIONS = new HashSet<RestOperationTypeEnum>();
+    RESOURCE_OPERATIONS.add(RestOperationTypeEnum.CREATE);
+    RESOURCE_OPERATIONS.add(RestOperationTypeEnum.UPDATE);
+  }
+
+  public static void log(
+    Claims jwt,
+    RequestDetails theRequestDetails,
+    RestOperationTypeEnum restOperationType
+  ) {
+    String username = getUsername(jwt);
+    logUsername(username, theRequestDetails, restOperationType);
+  }
+
+  // TBD: Allow unknown users or throw Exception here?
+  private static String getUsername(Claims jwt) {
+    if (!jwt.containsKey("preferred_username")) return "unknown";
+    return jwt.get("preferred_username").toString();
+  }
+
+  private static void logUsername(
+    String username,
+    RequestDetails theRequestDetails,
+    RestOperationTypeEnum restOperationType
+  ) {
+    setSentryUser(username);
+    theRequestDetails.setAttribute("_username", username);
+    if (RESOURCE_OPERATIONS.contains(restOperationType)) setResourceUserExtension(
+      username,
+      theRequestDetails
+    );
+  }
+
+  private static void setResourceUserExtension(
+    String username,
+    RequestDetails theRequestDetails
+  ) {
+    DomainResource theResource = (DomainResource) theRequestDetails.getResource();
+    Meta meta = theResource.getMeta();
+    Extension userExtension = new Extension();
+    userExtension.setUrl("https://simplifier.net/dot.base/requesting-username");
+    userExtension.setValue(new StringType().setValue(username));
+    meta.addExtension(userExtension);
+    theResource.setMeta(meta);
+    theRequestDetails.setResource(theResource);
+  }
+
+  private static void setSentryUser(String username) {
+    User user = new User();
+    user.setUsername(username);
+    Sentry.setUser(user);
+  }
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -22,6 +22,7 @@ public class UsernameLogger {
     RESOURCE_OPERATIONS = new HashSet<RestOperationTypeEnum>();
     RESOURCE_OPERATIONS.add(RestOperationTypeEnum.CREATE);
     RESOURCE_OPERATIONS.add(RestOperationTypeEnum.UPDATE);
+    RESOURCE_OPERATIONS.add(RestOperationTypeEnum.PATCH);
   }
 
   public static void log(

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -2,6 +2,7 @@ package ca.uhn.fhir.jpa.starter.dotBase.services;
 
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.AuthenticationException;
 import io.jsonwebtoken.Claims;
 import io.sentry.Sentry;
 import io.sentry.protocol.User;
@@ -35,7 +36,9 @@ public class UsernameLogger {
   }
 
   private static String getUsername(Claims jwt) {
-    if (!jwt.containsKey("preferred_username")) return "unknown";
+    if (!jwt.containsKey("preferred_username")) {
+      throw new AuthenticationException("Authentication failed - access token does not provide a username");
+    }
     return jwt.get("preferred_username").toString();
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -57,12 +57,10 @@ public class UsernameLogger {
     RequestDetails theRequestDetails
   ) {
     DomainResource theResource = (DomainResource) theRequestDetails.getResource();
-    Meta meta = theResource.getMeta();
     Extension userExtension = new Extension();
     userExtension.setUrl("https://simplifier.net/dot.base/requesting-username");
     userExtension.setValue(new StringType().setValue(username));
-    meta.addExtension(userExtension);
-    theResource.setMeta(meta);
+    theResource.addExtension(userExtension);
     theRequestDetails.setResource(theResource);
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/UsernameLogger.java
@@ -60,7 +60,7 @@ public class UsernameLogger {
     Meta meta = theResource.getMeta();
     List<Coding> tags = meta.getTag();
     Coding code = new Coding()
-    .setSystem("https://simplifier.net/dot.base/requesting-username");
+    .setSystem("https://simplifier.net/dot.base/requesting-username-namingsystem");
     code.setCode(username);
     tags.add(code);
     theResource.setMeta(meta.setTag(tags));


### PR DESCRIPTION
### 🚀 Description
This PR introduces logging the requester's username from jwt on POST PUT or PATCH requests


### 🧰 Technical Solution
- [x] add service usernameLogger
- [x] log username in case exception is sent to sentry
- [x] log username as `tag` to `resource.meta` like this :
```
    "meta": {
        "versionId": "1",
        "lastUpdated": "2021-04-13T21:14:45.109+02:00",
        "tag": [
            {
                "system": "https://simplifier.net/dot.base/requesting-username",
                "code": "movebasetester"
            }
        ]
    },
```

### ‼ Known Issues

A realm public key can be fetched on `<your-sso-url>/auth/realms/<realm-name>`.
You can use [this realm's public key](https://sso.movebase.charite.de/auth/realms/dotbase) to test the feature locally.