### PR TITLE
Fix/sentry integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,13 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-logback</artifactId>
-            <version>4.2.0</version>
+            <version>4.3.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-spring</artifactId>
+            <version>4.3.0</version>
         </dependency>
 
         <!-- Needed for JEE/Servlet support -->

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -4,11 +4,14 @@ import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.jpa.starter.dotBase.PlainSystemProviderR4;
 import ca.uhn.fhir.jpa.starter.dotBase.ResponseInterceptorExternalReference;
 import io.sentry.Sentry;
+import io.sentry.SentryOptions.Proxy;
 import javax.servlet.ServletException;
 
 public class JpaRestfulServer extends BaseJpaRestfulServer {
   private static final long serialVersionUID = 1L;
-  private static final String SENTRY_DSN = System.getenv("SENTRY_DSN") == null? "": System.getenv("SENTRY_DSN");
+  private static final String SENTRY_DSN = System.getenv("SENTRY_DSN") == null
+    ? ""
+    : System.getenv("SENTRY_DSN");
   private static final String SENTRY_ENV = System.getenv("SENTRY_ENVIRONMENT");
 
   @Override
@@ -23,6 +26,7 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
       options -> {
         options.setDsn(SENTRY_DSN);
         options.setEnvironment(SENTRY_ENV);
+        options.setProxy(new Proxy("http://proxy.charite.de", "8080"));
         options.setServerName(HapiProperties.getServerName());
         options.setTracesSampleRate(1.0);
         options.setConnectionTimeoutMillis(10000);


### PR DESCRIPTION
---
🧯 Bugfix
---

Fixes sentry integration for Java/Logback. 
Errors were not sent to Sentry due to broken config setup. To set configs via `sentry.init()` sentry-spring was needed.
Alternatively configs have to go to `logback.xml`

### 🚒 Technical Solution
[How did you fix this bug?]
- [ ] Add [sentry-spring 4.3.0](https://mvnrepository.com/artifact/io.sentry/sentry-spring/4.3.0) to pom.xml
