### PR TITLE
add creation date to resources

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AuditTrail.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AuditTrail.java
@@ -82,7 +82,7 @@ public class AuditTrail {
     DateTimeType now = new DateTimeType(Utils.getCurrentTimestamp());
     Coding creationDate = new Coding()
     .setSystem("https://simplifier.net/dot.base/resource-creation-datetime-namingsystem")
-    .setCode(now.toHumanDisplay());
+    .setCode(now.getValueAsString());
 
     DomainResource theResource = (DomainResource) theRequestDetails.getResource();
     Meta meta = theResource.getMeta();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AuditTrail.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AuditTrail.java
@@ -79,12 +79,16 @@ public class AuditTrail {
   }
 
   private static void setCreationDateTime(RequestDetails theRequestDetails) {
-    DomainResource theResource = (DomainResource) theRequestDetails.getResource();
     DateTimeType now = new DateTimeType(Utils.getCurrentTimestamp());
-    Extension creationDate = new Extension()
-      .setUrl("https://simplifier.net/dot.base/resource-creation-datetime")
-      .setValue(now);
-    theResource.getExtension().add(creationDate);
+    Coding creationDate = new Coding()
+    .setSystem("https://simplifier.net/dot.base/resource-creation-datetime-namingsystem")
+    .setCode(now.toHumanDisplay());
+
+    DomainResource theResource = (DomainResource) theRequestDetails.getResource();
+    Meta meta = theResource.getMeta();
+    List<Coding> tags = meta.getTag();
+    tags.add(creationDate);
+    theResource.setMeta(meta.setTag(tags));
     theRequestDetails.setResource(theResource);
   }
 }


### PR DESCRIPTION
### 🚀 Description
This PR introduces adding timestamp on creating resources to meta.tag like the following:
```
    "meta": {
        "versionId": "1",
        "lastUpdated": "2021-04-28T12:00:59.462+02:00",
        "tag": [
            {
                "system": "https://simplifier.net/dot.base/dotbase-username-namingsystem",
                "code": "other"
            },
            {
                "system": "https://simplifier.net/dot.base/resource-creation-datetime-namingsystem",
                "code": "2021-04-28T12:00:59+02:00"
            }
        ]
    }
```

### 🧰 Technical Solution
- [x] Add utility function to get current timestamp with local timezone and offset to UTC
- [x] Set current dateTime on meta.tag labeled as "https://simplifier.net/dot.base/resource-creation-datetime-namingsystem"
