### PR TITLE
Fix/transactions access log

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/PlainSystemProviderR4.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/PlainSystemProviderR4.java
@@ -18,7 +18,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.StringType;
-import org.springframework.web.context.ContextLoaderListener;
 
 public class PlainSystemProviderR4 extends JpaSystemProviderR4 {
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/entity/AccessLog.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/entity/AccessLog.java
@@ -14,6 +14,7 @@ import javax.persistence.Table;
   uniqueConstraints = {},
   indexes = {
     @Index(name = "IDX_LOG_ID", columnList = "LOG_ID", unique = true),
+    @Index(name = "IDX_REQUEST_ID", columnList = "REQUEST_ID", unique = true),
     @Index(name = "IDX_METHOD", columnList = "METHOD", unique = false),
     @Index(name = "IDX_USERNAME", columnList = "USERNAME", unique = false),
     @Index(name = "IDX_URL", columnList = "URL", unique = false),
@@ -26,6 +27,9 @@ public class AccessLog {
   @Column(name = "LOG_ID")
   @GeneratedValue(strategy = GenerationType.AUTO)
   public int id;
+
+  @Column(name = "REQUEST_ID")
+  public String requestId;
 
   @Column(name = "METHOD")
   public String method;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/entity/AccessLog.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/entity/AccessLog.java
@@ -14,7 +14,7 @@ import javax.persistence.Table;
   uniqueConstraints = {},
   indexes = {
     @Index(name = "IDX_LOG_ID", columnList = "LOG_ID", unique = true),
-    @Index(name = "IDX_REQUEST_ID", columnList = "REQUEST_ID", unique = true),
+    @Index(name = "IDX_REQUEST_ID", columnList = "REQUEST_ID", unique = false),
     @Index(name = "IDX_METHOD", columnList = "METHOD", unique = false),
     @Index(name = "IDX_USERNAME", columnList = "USERNAME", unique = false),
     @Index(name = "IDX_URL", columnList = "URL", unique = false),

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/model/AccessLogRepository.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/model/AccessLogRepository.java
@@ -22,6 +22,7 @@ public class AccessLogRepository {
 
   @Transactional
   public void createLog(
+    String requestId,
     String method,
     String username,
     String url,
@@ -29,6 +30,7 @@ public class AccessLogRepository {
     String timestamp
   ) {
     AccessLog logEntity = new AccessLog();
+    logEntity.requestId = requestId;
     logEntity.method = method;
     logEntity.username = username;
     logEntity.url = url;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
@@ -25,13 +25,14 @@ public class AuthenticationInterceptor {
     ServletRequestDetails servletRequestDetails,
     RestOperationTypeEnum restOperationType
   ) {
+    String username = "unknown";
     boolean isTransaction = restOperationType.equals(RestOperationTypeEnum.TRANSACTION);
     boolean isSubRequest =
       theRequestDetails.getUserData().get(PROCESSING_SUB_REQUEST) == Boolean.TRUE;
     boolean isAuthenticated = theRequestDetails.getAttribute("_username") != null;
 
     if (!isAuthenticated) {
-      String username = getAuthenticatedUser(theRequestDetails);
+      username = getAuthenticatedUser(theRequestDetails);
       theRequestDetails.setAttribute("_username", username);
       setSentryUser(username);
       AccessLog.logRequest(username, theRequestDetails, restOperationType);
@@ -39,6 +40,7 @@ public class AuthenticationInterceptor {
 
     if (isTransaction && !isSubRequest) {
       AuditTrail.handleTransaction(theRequestDetails);
+      AccessLog.handleTransaction(username, theRequestDetails);
     }
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AccessLog.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AccessLog.java
@@ -17,6 +17,7 @@ public class AccessLog {
     RestOperationTypeEnum restOperationType
   ) {
     ACCESS_LOG_REPOSITORY.createLog(
+      theRequestDetails.getRequestId(),
       restOperationType.toString(),
       username,
       theRequestDetails.getCompleteUrl(),

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AccessLog.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AccessLog.java
@@ -4,6 +4,9 @@ import ca.uhn.fhir.jpa.starter.dotBase.entities.model.AccessLogRepository;
 import ca.uhn.fhir.jpa.starter.dotBase.utils.DateUtils;
 import ca.uhn.fhir.rest.api.RestOperationTypeEnum;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import java.util.List;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.springframework.web.context.ContextLoaderListener;
 
 public class AccessLog {
@@ -22,6 +25,45 @@ public class AccessLog {
       username,
       theRequestDetails.getCompleteUrl(),
       theRequestDetails.getResourceName(),
+      DateUtils.getCurrentTimestamp()
+    );
+  }
+
+  public static void handleTransaction(String username, RequestDetails theRequest) {
+    if (theRequest.getResource() instanceof Bundle) {
+      Bundle theResource = (Bundle) theRequest.getResource();
+      List<BundleEntryComponent> entries = theResource.getEntry();
+      entries.forEach(entry -> transactionEntry(username, theRequest, entry));
+    }
+  }
+
+  private static void transactionEntry(
+    String username,
+    RequestDetails theRequest,
+    BundleEntryComponent entry
+  ) {
+    logSubRequest(
+      theRequest.getRequestId(),
+      entry.getRequest().getMethod().toCode(),
+      username,
+      entry.getRequest().getUrl(),
+      entry.getResource().getResourceType().name()
+    );
+  }
+
+  public static void logSubRequest(
+    String requestId,
+    String method,
+    String username,
+    String url,
+    String resourceType
+  ) {
+    ACCESS_LOG_REPOSITORY.createLog(
+      requestId,
+      method,
+      username,
+      url,
+      resourceType,
       DateUtils.getCurrentTimestamp()
     );
   }


### PR DESCRIPTION
Currently subrequests of transactions are logged only once for the main reuqest on `api/fhir`.
This PR fixes logging subrequests and add requestIds to all access logs.

### 🚒 Technical Solution
- [x] add column `requestId` to AccessLog
- [x] add `AccessLog.handleTransaction` to handle `Bundle.entries` of transactions separately