### PR TITLE
fix datatype of column url in AccessLog Table

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/entity/AccessLog.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/entities/entity/AccessLog.java
@@ -37,7 +37,7 @@ public class AccessLog {
   @Column(name = "USERNAME")
   public String username;
 
-  @Column(name = "URL")
+  @Column(name = "URL", columnDefinition = "TEXT")
   public String url;
 
   @Column(name = "TIMESTAMP")


### PR DESCRIPTION
This PR fixes the following SQL Error for the AccessLogging Table:
`ERROR: value too long for type character varying(255)
`
### 🚒 Technical Solution
- [x] Change datatype of column `URL` to Text instead of default type varchar(255)
