### PR TITLE
change dataType of resourceEditor.value from string to Code

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AuditTrail.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/services/AuditTrail.java
@@ -19,6 +19,7 @@ import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.HTTPVerb;
+import org.hl7.fhir.r4.model.CodeType;
 import org.hl7.fhir.r4.model.DateTimeType;
 import org.hl7.fhir.r4.model.IdType;
 import org.hl7.fhir.r4.model.Resource;
@@ -44,7 +45,7 @@ public class AuditTrail {
   public static void setResourceEditor(RequestDetails theRequest, IBaseResource theResource) {
     String username = getUsername(theRequest);
     String system = DotbaseProperties.get("Url.StructureDefinition.ResourceEditor");
-    ExtensionUtils.addExtension(theResource, system, username);
+    ExtensionUtils.addExtension(theResource, system, new CodeType(username));
   }
 
   public static void handleTransaction(RequestDetails theRequest) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/utils/ExtensionUtils.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/utils/ExtensionUtils.java
@@ -8,16 +8,19 @@ import org.hl7.fhir.instance.model.api.IBaseDatatype;
 import org.hl7.fhir.instance.model.api.IBaseExtension;
 import org.hl7.fhir.instance.model.api.IBaseHasExtensions;
 import org.hl7.fhir.instance.model.api.IBaseResource;
-import org.hl7.fhir.r4.model.StringType;
 
 public class ExtensionUtils {
 
-  public static void addExtension(IBaseResource theResource, String theUrl, String theValue) {
+  public static void addExtension(
+    IBaseResource theResource,
+    String theUrl,
+    IBaseDatatype theValue
+  ) {
     try {
       IBaseHasExtensions baseHasExtensions = validateExtensionSupport(theResource);
       IBaseExtension<?, ?> extension = baseHasExtensions.addExtension();
       extension.setUrl(theUrl);
-      extension.setValue(new StringType(theValue));
+      extension.setValue(theValue);
     } catch (Exception e) {
       return;
     }


### PR DESCRIPTION
If Validation is enabled the dot.base frontend crashes, if a resource is updated. This is due to `resource-editor` being set as a valueString instead of a valueCode as defined by the corresponding Extension and NamingSystem

### 🚒 Technical Solution
[How did you fix this bug?]
- [x] changes the dataType of resourceEditor.value from string to code