### PR TITLE
Feature - Secure endpoints for admin access only

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -8,7 +8,7 @@ import ca.uhn.fhir.jpa.starter.dotBase.entities.AccessLogProvider;
 import ca.uhn.fhir.jpa.starter.dotBase.interceptors.AuditTrailInterceptor;
 import ca.uhn.fhir.jpa.starter.dotBase.interceptors.AuthenticationInterceptor;
 import ca.uhn.fhir.jpa.starter.dotBase.interceptors.ResponseInterceptor;
-import ca.uhn.fhir.jpa.starter.dotBase.interceptors.UserAuthorizationIntercerptor;
+import ca.uhn.fhir.jpa.starter.dotBase.interceptors.UserAuthorizationInterceptor;
 import ca.uhn.fhir.jpa.starter.dotBase.services.Authorization;
 import ca.uhn.fhir.rest.server.interceptor.consent.ConsentInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.consent.IConsentService;
@@ -50,7 +50,7 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
       consentInterceptor.setConsentService(authorizationService);
       registerInterceptor(consentInterceptor);
 
-      registerInterceptor(new UserAuthorizationIntercerptor());
+      registerInterceptor(new UserAuthorizationInterceptor());
     }
 
     if (HapiProperties.isErrorMonitorinEnabled()) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -8,6 +8,7 @@ import ca.uhn.fhir.jpa.starter.dotBase.entities.AccessLogProvider;
 import ca.uhn.fhir.jpa.starter.dotBase.interceptors.AuditTrailInterceptor;
 import ca.uhn.fhir.jpa.starter.dotBase.interceptors.AuthenticationInterceptor;
 import ca.uhn.fhir.jpa.starter.dotBase.interceptors.ResponseInterceptor;
+import ca.uhn.fhir.jpa.starter.dotBase.interceptors.UserAuthorizationIntercerptor;
 import ca.uhn.fhir.jpa.starter.dotBase.services.Authorization;
 import ca.uhn.fhir.rest.server.interceptor.consent.ConsentInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.consent.IConsentService;
@@ -48,6 +49,8 @@ public class JpaRestfulServer extends BaseJpaRestfulServer {
       ConsentInterceptor consentInterceptor = new ConsentInterceptor();
       consentInterceptor.setConsentService(authorizationService);
       registerInterceptor(consentInterceptor);
+
+      registerInterceptor(new UserAuthorizationIntercerptor());
     }
 
     if (HapiProperties.isErrorMonitorinEnabled()) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/DotbaseProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/DotbaseProperties.java
@@ -12,6 +12,7 @@ public class DotbaseProperties {
       InputStream input =
         DotbaseProperties.class.getClassLoader().getResourceAsStream("dotbase.properties");
       prop.load(input);
+      input.close();
     } catch (IOException e) {
       // TODO Auto-generated catch block
       e.printStackTrace();

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
@@ -54,10 +54,10 @@ public class AuthenticationInterceptor {
       return getUsername(jwt);
     }
     String xForwardedUser = theRequestDetails.getHeader("X-Forwarded-User");
-    if (xForwardedUser != null && !xForwardedUser.equals("")) {
-      return theRequestDetails.getHeader("X-Forwarded-User");
-    }
-    throw new AuthenticationException("Authentication failed");
+    if (xForwardedUser == null || xForwardedUser.equals("")) throw new AuthenticationException(
+      "Authentication failed"
+    );
+    return xForwardedUser;
   }
 
   private String getUsername(Claims jwt) {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/AuthenticationInterceptor.java
@@ -53,7 +53,8 @@ public class AuthenticationInterceptor {
       Claims jwt = Authentication.verifyAndDecodeJWT(theRequestDetails);
       return getUsername(jwt);
     }
-    if (theRequestDetails.getHeader("X-Forwarded-User") != null) {
+    String xForwardedUser = theRequestDetails.getHeader("X-Forwarded-User");
+    if (xForwardedUser != null && !xForwardedUser.equals("")) {
       return theRequestDetails.getHeader("X-Forwarded-User");
     }
     throw new AuthenticationException("Authentication failed");

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationInterceptor.java
@@ -1,49 +1,53 @@
 package ca.uhn.fhir.jpa.starter.dotBase.interceptors;
 
+import ca.uhn.fhir.jpa.starter.HapiProperties;
 import ca.uhn.fhir.jpa.starter.dotBase.DotbaseProperties;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
 import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
 import java.util.List;
 
 /**
- * Determines whether the caller is admin, normal user or no user
- * and authorizes access accordingly.
- *
- * @pre register after {@link AuthenticationInterceptor}
+ * Determines whether the caller is admin, normal user or no user and authorizes
+ * access accordingly.
  */
 public class UserAuthorizationInterceptor extends AuthorizationInterceptor {
+  private static final String[] RESTRICTED_ENDPOINTS = {
+    "$logs",
+    "$mark-all-resources-for-reindexing",
+    "$meta-delete"
+  };
+
   private static final List<IAuthRule> ADMIN_RULES = new RuleBuilder().allowAll().build();
   private static final List<IAuthRule> DENY_ALL_RULES = new RuleBuilder().denyAll().build();
-  private static final List<IAuthRule> USER_RULES = new RuleBuilder()
-    .deny("Log access forbidden for non-admin")
-    .operation()
-    .named("$logs")
-    .atAnyLevel()
-    .andAllowAllResponses()
-    .andThen()
-    .deny("Force-reindexing forbidden for non-admin")
-    .operation()
-    .named("$mark-all-resources-for-reindexing")
-    .atAnyLevel()
-    .andAllowAllResponses()
-    .andThen()
-    .deny("Deleting meta forbidden for non-admin")
-    .operation()
-    .named("$meta-delete")
-    .atAnyLevel()
-    .andAllowAllResponses()
-    .andThen()
-    .allowAll()
-    .build();
+  private static final List<IAuthRule> USER_RULES = buildUserRules();
+
+  private static List<IAuthRule> buildUserRules() {
+    RuleBuilder ruleBuilder = new RuleBuilder();
+    for (String endpoint : RESTRICTED_ENDPOINTS) ruleBuilder
+      .deny("Restricted Endpoint or Operation - " + endpoint)
+      .operation()
+      .named("$logs")
+      .atAnyLevel()
+      .andAllowAllResponses()
+      .andThen();
+    return ruleBuilder.allowAll().build();
+  }
 
   private String getUsername(RequestDetails theRequestDetails) {
-    return theRequestDetails.getAttribute("_username").toString();
+    String username = theRequestDetails.getAttribute("_username").toString();
+    if (username == null) throw new Error("Missing username");
+    return username;
   }
 
   private boolean isAdmin(String username) {
-    return username.equals(DotbaseProperties.get("Dotbase.AdminUserName"));
+    String adminUserName = DotbaseProperties.get("Dotbase.AdminUserName");
+    if (adminUserName == null || adminUserName.equals("")) System.out.println(
+      "WARN: No admin user set in dotbase.properties"
+    );
+    return username.equals(adminUserName);
   }
 
   private boolean isUser(String username) {
@@ -52,8 +56,9 @@ public class UserAuthorizationInterceptor extends AuthorizationInterceptor {
 
   @Override
   public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
-    String username = getUsername(theRequestDetails);
+    if (!HapiProperties.isAuthenticationInterceptorEnabled()) return ADMIN_RULES;
 
+    String username = getUsername(theRequestDetails);
     if (isAdmin(username)) return ADMIN_RULES;
     if (isUser(username)) return USER_RULES;
     return DENY_ALL_RULES;

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationInterceptor.java
@@ -13,7 +13,7 @@ import java.util.List;
  *
  * @pre register after {@link AuthenticationInterceptor}
  */
-public class UserAuthorizationIntercerptor extends AuthorizationInterceptor {
+public class UserAuthorizationInterceptor extends AuthorizationInterceptor {
   private static final List<IAuthRule> ADMIN_RULES = new RuleBuilder().allowAll().build();
   private static final List<IAuthRule> DENY_ALL_RULES = new RuleBuilder().denyAll().build();
   private static final List<IAuthRule> USER_RULES = new RuleBuilder()

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationInterceptor.java
@@ -3,7 +3,6 @@ package ca.uhn.fhir.jpa.starter.dotBase.interceptors;
 import ca.uhn.fhir.jpa.starter.HapiProperties;
 import ca.uhn.fhir.jpa.starter.dotBase.DotbaseProperties;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
-import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
 import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
@@ -14,6 +13,10 @@ import java.util.List;
  * access accordingly.
  */
 public class UserAuthorizationInterceptor extends AuthorizationInterceptor {
+  private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(
+    UserAuthorizationInterceptor.class
+  );
+
   private static final String[] RESTRICTED_ENDPOINTS = {
     "$logs",
     "$mark-all-resources-for-reindexing",
@@ -44,8 +47,8 @@ public class UserAuthorizationInterceptor extends AuthorizationInterceptor {
 
   private boolean isAdmin(String username) {
     String adminUserName = DotbaseProperties.get("Dotbase.AdminUserName");
-    if (adminUserName == null || adminUserName.equals("")) System.out.println(
-      "WARN: No admin user set in dotbase.properties"
+    if (adminUserName == null || adminUserName.equals("")) ourLog.warn(
+      "Missing property admin username."
     );
     return username.equals(adminUserName);
   }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationIntercerptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationIntercerptor.java
@@ -1,0 +1,63 @@
+package ca.uhn.fhir.jpa.starter.dotBase.interceptors;
+
+import java.util.List;
+import ca.uhn.fhir.jpa.starter.dotBase.DotbaseProperties;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
+import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
+import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
+
+/**
+ * Determines whether the caller is admin, normal user or no user
+ * and authorizes accordingly.
+ * 
+ * @pre register after {@link AuthenticationInterceptor}
+ */
+public class UserAuthorizationIntercerptor extends AuthorizationInterceptor {
+    private static final List<IAuthRule> ADMIN_RULES = new RuleBuilder()
+            .allowAll().build();
+    private static final List<IAuthRule> USER_RULES = new RuleBuilder()
+            .deny("Log acess forbidden for non-admin")
+                .operation()
+                .named("$logs")
+                .atAnyLevel()
+                .andAllowAllResponses()
+                .andThen()
+            .deny("Force-reindexing forbidden for non-admin")
+                .operation()
+                .named("$mark-all-resources-for-reindexing")
+                .atAnyLevel()
+                .andAllowAllResponses()
+                .andThen()
+            .deny("Deleting meta (profiles, tags, security labels) forbidden for non-admin")
+                .operation()
+                .named("$meta-delete")
+                .atAnyLevel()
+                .andAllowAllResponses()
+                .andThen()
+            .allowAll().build();
+    private static final List<IAuthRule> DENY_ALL_RULES = new RuleBuilder()
+            .denyAll().build();
+    
+    private String getUsername(RequestDetails theRequestDetails) {
+        return theRequestDetails.getAttribute("_username").toString();
+    }
+
+    private boolean isUserAdmin(String username) {
+        return username == DotbaseProperties.get("Dotbase.AdminUserName");
+    }
+
+    private boolean isUser(String username) {
+        return username != null;
+    }
+
+    @Override
+    public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
+        String username = getUsername(theRequestDetails);
+
+        if (isUserAdmin(username)) return ADMIN_RULES;
+        if (isUser(username)) return USER_RULES;
+        return DENY_ALL_RULES;
+    }
+
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationIntercerptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationIntercerptor.java
@@ -1,63 +1,61 @@
 package ca.uhn.fhir.jpa.starter.dotBase.interceptors;
 
-import java.util.List;
 import ca.uhn.fhir.jpa.starter.dotBase.DotbaseProperties;
 import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.IAuthRule;
 import ca.uhn.fhir.rest.server.interceptor.auth.RuleBuilder;
+import java.util.List;
 
 /**
  * Determines whether the caller is admin, normal user or no user
- * and authorizes accordingly.
- * 
+ * and authorizes access accordingly.
+ *
  * @pre register after {@link AuthenticationInterceptor}
  */
 public class UserAuthorizationIntercerptor extends AuthorizationInterceptor {
-    private static final List<IAuthRule> ADMIN_RULES = new RuleBuilder()
-            .allowAll().build();
-    private static final List<IAuthRule> USER_RULES = new RuleBuilder()
-            .deny("Log acess forbidden for non-admin")
-                .operation()
-                .named("$logs")
-                .atAnyLevel()
-                .andAllowAllResponses()
-                .andThen()
-            .deny("Force-reindexing forbidden for non-admin")
-                .operation()
-                .named("$mark-all-resources-for-reindexing")
-                .atAnyLevel()
-                .andAllowAllResponses()
-                .andThen()
-            .deny("Deleting meta forbidden for non-admin")
-                .operation()
-                .named("$meta-delete")
-                .atAnyLevel()
-                .andAllowAllResponses()
-                .andThen()
-            .allowAll().build();
-    private static final List<IAuthRule> DENY_ALL_RULES = new RuleBuilder()
-            .denyAll().build();
-    
-    private String getUsername(RequestDetails theRequestDetails) {
-        return theRequestDetails.getAttribute("_username").toString();
-    }
+  private static final List<IAuthRule> ADMIN_RULES = new RuleBuilder().allowAll().build();
+  private static final List<IAuthRule> DENY_ALL_RULES = new RuleBuilder().denyAll().build();
+  private static final List<IAuthRule> USER_RULES = new RuleBuilder()
+    .deny("Log access forbidden for non-admin")
+    .operation()
+    .named("$logs")
+    .atAnyLevel()
+    .andAllowAllResponses()
+    .andThen()
+    .deny("Force-reindexing forbidden for non-admin")
+    .operation()
+    .named("$mark-all-resources-for-reindexing")
+    .atAnyLevel()
+    .andAllowAllResponses()
+    .andThen()
+    .deny("Deleting meta forbidden for non-admin")
+    .operation()
+    .named("$meta-delete")
+    .atAnyLevel()
+    .andAllowAllResponses()
+    .andThen()
+    .allowAll()
+    .build();
 
-    private boolean isUserAdmin(String username) {
-        return username == DotbaseProperties.get("Dotbase.AdminUserName");
-    }
+  private String getUsername(RequestDetails theRequestDetails) {
+    return theRequestDetails.getAttribute("_username").toString();
+  }
 
-    private boolean isUser(String username) {
-        return username != null;
-    }
+  private boolean isAdmin(String username) {
+    return username.equals(DotbaseProperties.get("Dotbase.AdminUserName"));
+  }
 
-    @Override
-    public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
-        String username = getUsername(theRequestDetails);
+  private boolean isUser(String username) {
+    return username != null;
+  }
 
-        if (isUserAdmin(username)) return ADMIN_RULES;
-        if (isUser(username)) return USER_RULES;
-        return DENY_ALL_RULES;
-    }
+  @Override
+  public List<IAuthRule> buildRuleList(RequestDetails theRequestDetails) {
+    String username = getUsername(theRequestDetails);
 
+    if (isAdmin(username)) return ADMIN_RULES;
+    if (isUser(username)) return USER_RULES;
+    return DENY_ALL_RULES;
+  }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationIntercerptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotBase/interceptors/UserAuthorizationIntercerptor.java
@@ -29,7 +29,7 @@ public class UserAuthorizationIntercerptor extends AuthorizationInterceptor {
                 .atAnyLevel()
                 .andAllowAllResponses()
                 .andThen()
-            .deny("Deleting meta (profiles, tags, security labels) forbidden for non-admin")
+            .deny("Deleting meta forbidden for non-admin")
                 .operation()
                 .named("$meta-delete")
                 .atAnyLevel()

--- a/src/main/resources/dotbase.properties
+++ b/src/main/resources/dotbase.properties
@@ -2,3 +2,4 @@ Url.NamingSystem.CreationDateTime=https://dotbase.org/fhir/NamingSystem/creation
 Url.NamingSystem.DotbaseUsername=https://dotbase.org/fhir/NamingSystem/dotbase-username
 Url.StructureDefinition.ResourceEditor=https://dotbase.org/fhir/StructureDefinition/resource-editor
 Url.StructureDefinition.DocumentDraftAction=https://dotbase.org/fhir/StructureDefinition/document-draft-action
+Dotbase.AdminUserName=test-admin

--- a/src/main/resources/dotbase.properties
+++ b/src/main/resources/dotbase.properties
@@ -2,4 +2,4 @@ Url.NamingSystem.CreationDateTime=https://dotbase.org/fhir/NamingSystem/creation
 Url.NamingSystem.DotbaseUsername=https://dotbase.org/fhir/NamingSystem/dotbase-username
 Url.StructureDefinition.ResourceEditor=https://dotbase.org/fhir/StructureDefinition/resource-editor
 Url.StructureDefinition.DocumentDraftAction=https://dotbase.org/fhir/StructureDefinition/document-draft-action
-Dotbase.AdminUserName=test-admin
+Dotbase.AdminUserName=


### PR DESCRIPTION
### 🚀 Feature Description
This PR introduces secure endpoints for admin access only. This resolves #43.

As I've found only three endpoints to secure, I opted for a blacklist authorization, i.e. normal users may do everything _but_ the denied operations. This seemed favorable compared to the alternative where i would basically need to allow all endpoints manually, something like below: 

```
IAuthRuleBuilder authNormalUserRules = new RuleBuilder()
            .allow().read().allResources().withAnyId().andThen()
            .allow().create().allResources().withAnyId().andThen()
            .allow().createConditional().allResources().andThen()
            .allow().write().allResources().withAnyId().andThen()
            .allow().delete().allResources().withAnyId().andThen()
            .allow().deleteConditional().allResources().andThen()
            .allow().patch().allRequests().andThen()
            .allow().graphQL().any().andThen()
            .allow().metadata().andThen();
            // + all (!) operations that are permitted but not the three forbidden ones
	    // + allow transactions
```

### 🧰 Technical Solution
- [x] Add AuthenticationInterceptor
- [x] Register AuthenticationInterceptor in JpaRestfulServer.java

#### 🧯 Minor other bugfixes
- [x] Close inputstream in DotbaseProperties.java
- [x] Throw 'no authentication' error if x-forwarded-user is set to empty String ""
