### PR TITLE
Fix concurrency errors on transactions

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotbase/utils/MetaUtils.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotbase/utils/MetaUtils.java
@@ -29,5 +29,6 @@ public class MetaUtils {
 
     tagElement.setSystem(theSystem);
     tagElement.setCode(theValue);
+    tagElement.setDisplay(theValue + "-" + DateUtils.getCurrentTimestamp());
   }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotbase/utils/MetaUtils.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotbase/utils/MetaUtils.java
@@ -3,6 +3,8 @@ package ca.uhn.fhir.jpa.starter.dotbase.utils;
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.jpa.starter.dotbase.DotbaseProperties.ResourceUrls;
+
 import java.util.List;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
@@ -27,8 +29,23 @@ public class MetaUtils {
       sourceChild.getMutator().setValue(theMeta, tagElement);
     }
 
+
+
+    String theCode = MetaUtils.getTagElementCode(theSystem, theValue);
     tagElement.setSystem(theSystem);
-    tagElement.setCode(theValue);
-    tagElement.setDisplay(theValue + "-" + DateUtils.getCurrentTimestamp());
+    tagElement.setDisplay(theValue);
+    tagElement.setCode(theCode);
   }
+  
+  private static String getTagElementCode(String theSystem, String theValue) {
+    if(enforceUniqueCode(theSystem)) {
+      theValue+="-"+DateUtils.getCurrentTimestamp();
+    }
+    return theValue;
+  }
+
+  private static boolean enforceUniqueCode(String theSystem) {
+    return theSystem.equals(ResourceUrls.namingsystem_dotbase_username);
+  }
+  
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/dotbase/utils/MetaUtils.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/dotbase/utils/MetaUtils.java
@@ -3,9 +3,8 @@ package ca.uhn.fhir.jpa.starter.dotbase.utils;
 import ca.uhn.fhir.context.BaseRuntimeChildDefinition;
 import ca.uhn.fhir.context.BaseRuntimeElementCompositeDefinition;
 import ca.uhn.fhir.context.FhirContext;
-import ca.uhn.fhir.jpa.starter.dotbase.DotbaseProperties.ResourceUrls;
-
 import java.util.List;
+import java.util.Random;
 import org.hl7.fhir.instance.model.api.IBase;
 import org.hl7.fhir.instance.model.api.IBaseCoding;
 import org.hl7.fhir.instance.model.api.IBaseMetaType;
@@ -15,7 +14,7 @@ public class MetaUtils {
   private static final org.slf4j.Logger ourLog = org.slf4j.LoggerFactory.getLogger(MetaUtils.class);
 
   public static void setTag(FhirContext theContext, IBaseResource theResource, String theSystem, String theValue) {
-    
+
     IBaseMetaType theMeta = theResource.getMeta();
     BaseRuntimeElementCompositeDefinition<?> elementDef = (BaseRuntimeElementCompositeDefinition<?>) theContext
         .getElementDefinition(theMeta.getClass());
@@ -29,23 +28,24 @@ public class MetaUtils {
       sourceChild.getMutator().setValue(theMeta, tagElement);
     }
 
-
-
-    String theCode = MetaUtils.getTagElementCode(theSystem, theValue);
+    String theCode = getTagElementCode(theValue);
     tagElement.setSystem(theSystem);
     tagElement.setDisplay(theValue);
     tagElement.setCode(theCode);
   }
-  
-  private static String getTagElementCode(String theSystem, String theValue) {
-    if(enforceUniqueCode(theSystem)) {
-      theValue+="-"+DateUtils.getCurrentTimestamp();
-    }
+
+  /**
+   * --- Generates a unique value for meta.tag.code --- Otherwise duplicate values
+   * in table hfj_tag_def occure, which leads to HTTP 500 being returned with
+   * error message "ConstraintViolationException: could not execute batch"
+   */
+  private static String getTagElementCode(String theValue) {
+    theValue += "-" + DateUtils.getCurrentTimestamp() + "-" + enforceUniqueCode();
     return theValue;
   }
 
-  private static boolean enforceUniqueCode(String theSystem) {
-    return theSystem.equals(ResourceUrls.namingsystem_dotbase_username);
+  private static Long enforceUniqueCode() {
+    return new Random().nextLong();
   }
-  
+
 }


### PR DESCRIPTION
### 🧯 Bugfix Description
This PR fixes the following concurrency errors:

- If a resource is created a `resource-creator` is added to `resource.meta`. For resources with the same creator only one single database tag entry is created in the table `hfj_tag_def`. This leads to conflicts (`HTTP 409`) when deleting resources because all resources, that were created by the same dotbase user, share this one creator tag.

- If a resource is created a `resource-creator` and `creation-datetime` are added to `resource.meta`.  Currently, creating resources fails randomly with `HTTP 500 - DataIntegrityViolationException: could not execute batch` . This is due to duplicate values for meta.tag that cannot be added to the table  `hfj_tag_def`.

### 🧰 Technical Solution
- [x] Generate a unique value for `meta.tag.code` using the current datetime and a random long to avoid duplicates a 
 `ConstraintViolationException` being thrown
- [x] Use `meta.tag.display` (instead of `meta.tag.code`) to set the value of resource-creator and creation-datetime, since meta.tag.code has to be unique.

